### PR TITLE
Optimize Order struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,28 +235,25 @@ List all the options and their order books: <http://localhost:8090/v0/options>
   "Chain": "Solana",          // Ethereum, Solana...
   "Layer": "L1",
   "Provider": "PsyOptions",   // Opyn, Lyra, Thales, Deribit, Psyoptions
+  "QuoteCurrency": "USDC" // ETH, BTC...
   "Bid": [
     {
       "Price": 13.3,
       "Quantity": 5,
-      "QuoteCurrency": "USDC" // ETH, BTC...
     },
     {
       "Price": 13.1,
       "Quantity": 10,
-      "QuoteCurrency": "USDC"
     }
   ],
   "Ask": [
     {
       "Price": 15.12,
       "Quantity": 5,
-      "QuoteCurrency": "USDC"
     },
     {
       "Price": 15.25,
       "Quantity": 9,
-      "QuoteCurrency": "USDC"
     }
   ]
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -21,16 +21,12 @@ import (
 
 func main() {
 	service := rainbow.NewService(provider.AllProvider{}, &dbram.DB{})
+
 	options, err := service.OptionsFromProviders()
 	if err != nil {
 		log.Print("ERROR: ", err)
 		return
 	}
-	/*options, err := deribit.Options()
-	if err != nil {
-		log.Print("ERROR: ", err)
-		return
-	}*/
 
 	printTable(options)
 }
@@ -42,12 +38,12 @@ func printTable(options []rainbow.Option) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.SetStyle(table.StyleLight)
-	t.SetTitle(fmt.Sprint("\t\t 2021 CeDeFi options: ", len(options)))
+	t.SetTitle(fmt.Sprint("\t\t CeDeFi options: ", len(options)))
 
 	t.AppendHeader(table.Row{
 		"Provider", "Asset", "Type",
-		"Bid size", "Bid Price", "Strike",
-		"Ask Price", "Ask size", "Instrument",
+		"Bid size", "Bid px", "Strike",
+		"Ask px", "Ask size", "Instrument",
 	})
 
 	for _, option := range options {

--- a/pkg/provider/deribit/deribit.go
+++ b/pkg/provider/deribit/deribit.go
@@ -179,12 +179,12 @@ func normalize(instruments []instrument, depth uint32) ([]rainbow.Option, error)
 
 		bids := normalizeOrders(result.Result.Bids)
 		sort.Slice(bids, func(i, j int) bool {
-			return bids[i].Price > bids[j].Price
+			return bids[i].Px > bids[j].Px
 		})
 
 		asks := normalizeOrders(result.Result.Asks)
 		sort.Slice(asks, func(i, j int) bool {
-			return asks[i].Price < asks[j].Price
+			return asks[i].Px < asks[j].Px
 		})
 
 		options = append(options, rainbow.Option{
@@ -250,12 +250,12 @@ func normalizeOrders(orders [][]float64) []rainbow.Order {
 	// if there is no offer, send price=0.0, quant=0.0
 	// hopefully we never an array of empty array
 	if len(orders) == 0 {
-		return []rainbow.Order{{Price: 0.0, Quantity: 0.0}}
+		return []rainbow.Order{{Px: 0.0, Size: 0.0}}
 	}
 
 	offers := make([]rainbow.Order, 0, len(orders))
 	for _, ord := range orders {
-		offers = append(offers, rainbow.Order{Price: ord[0], Quantity: ord[1]})
+		offers = append(offers, rainbow.Order{Px: ord[0], Size: ord[1]})
 	}
 
 	return offers

--- a/pkg/provider/deribit/deribit.go
+++ b/pkg/provider/deribit/deribit.go
@@ -177,28 +177,29 @@ func normalize(instruments []instrument, depth uint32) ([]rainbow.Option, error)
 		expiryTime := time.Unix(seconds, ns).UTC()
 		expiryStr := expiryTime.Format("2006-01-02 15:04:05")
 
-		bids := normalizeOrders(result.Result.Bids, i.QuoteCurrency)
+		bids := normalizeOrders(result.Result.Bids)
 		sort.Slice(bids, func(i, j int) bool {
 			return bids[i].Price > bids[j].Price
 		})
 
-		asks := normalizeOrders(result.Result.Asks, i.QuoteCurrency)
+		asks := normalizeOrders(result.Result.Asks)
 		sort.Slice(asks, func(i, j int) bool {
 			return asks[i].Price < asks[j].Price
 		})
 
 		options = append(options, rainbow.Option{
-			Name:         i.InstrumentName,
-			Type:         strings.ToUpper(i.OptionType),
-			Asset:        i.BaseCurrency,
-			Expiry:       expiryStr,
-			Strike:       i.Strike,
-			ExchangeType: "CEX",
-			Chain:        "–",
-			Layer:        "–",
-			Provider:     "Deribit",
-			Bid:          bids,
-			Ask:          asks,
+			Name:          i.InstrumentName,
+			Type:          strings.ToUpper(i.OptionType),
+			Asset:         i.BaseCurrency,
+			Expiry:        expiryStr,
+			Strike:        i.Strike,
+			ExchangeType:  "CEX",
+			Chain:         "–",
+			Layer:         "–",
+			Provider:      "Deribit",
+			QuoteCurrency: i.QuoteCurrency,
+			Bid:           bids,
+			Ask:           asks,
 		})
 	}
 
@@ -245,16 +246,16 @@ type OrderBook struct {
 	AskIv                  float64 `json:"ask_iv"`
 }
 
-func normalizeOrders(orders [][]float64, quote string) []rainbow.Order {
+func normalizeOrders(orders [][]float64) []rainbow.Order {
 	// if there is no offer, send price=0.0, quant=0.0
 	// hopefully we never an array of empty array
 	if len(orders) == 0 {
-		return []rainbow.Order{{Price: 0.0, Quantity: 0.0, QuoteCurrency: quote}}
+		return []rainbow.Order{{Price: 0.0, Quantity: 0.0}}
 	}
 
 	offers := make([]rainbow.Order, 0, len(orders))
 	for _, ord := range orders {
-		offers = append(offers, rainbow.Order{Price: ord[0], Quantity: ord[1], QuoteCurrency: quote})
+		offers = append(offers, rainbow.Order{Price: ord[0], Quantity: ord[1]})
 	}
 
 	return offers

--- a/pkg/provider/psyoptions/psyoptions.go
+++ b/pkg/provider/psyoptions/psyoptions.go
@@ -84,17 +84,18 @@ func Options() ([]rainbow.Option, error) {
 		}
 
 		options = append(options, rainbow.Option{
-			Name:         i.name(),
-			Type:         i.optionType(),
-			Asset:        i.asset(),
-			Expiry:       Expiration,
-			Strike:       i.strike(),
-			ExchangeType: "DEX",
-			Chain:        "Solana",
-			Layer:        "L1",
-			Provider:     "PsyOptions",
-			Bid:          bids,
-			Ask:          asks,
+			Name:          i.name(),
+			Type:          i.optionType(),
+			Asset:         i.asset(),
+			Expiry:        Expiration,
+			Strike:        i.strike(),
+			ExchangeType:  "DEX",
+			Chain:         "Solana",
+			Layer:         "L1",
+			Provider:      "PsyOptions",
+			QuoteCurrency: PsyQuoteCurrency,
+			Bid:           bids,
+			Ask:           asks,
 		})
 	}
 
@@ -137,9 +138,8 @@ func normalizeOrders(ctx context.Context, market *serum.MarketMeta, cli *rpc.Cli
 
 		offers = append(offers,
 			rainbow.Order{
-				Price:         price,
-				Quantity:      qty,
-				QuoteCurrency: PsyQuoteCurrency,
+				Price:    price,
+				Quantity: qty,
 			},
 		)
 	}

--- a/pkg/provider/psyoptions/psyoptions.go
+++ b/pkg/provider/psyoptions/psyoptions.go
@@ -138,8 +138,8 @@ func normalizeOrders(ctx context.Context, market *serum.MarketMeta, cli *rpc.Cli
 
 		offers = append(offers,
 			rainbow.Order{
-				Price:    price,
-				Quantity: qty,
+				Px:   price,
+				Size: qty,
 			},
 		)
 	}

--- a/pkg/provider/zerox/0x.go
+++ b/pkg/provider/zerox/0x.go
@@ -308,8 +308,8 @@ func normalizeOrders(records []Record) ([]rainbow.Order, error) {
 		offers = append(
 			offers,
 			rainbow.Order{
-				Price:    makerAmount / takerAmount,
-				Quantity: takerAmount * math.Pow(10, -float64(OTokensDecimals)),
+				Px:   makerAmount / takerAmount,
+				Size: takerAmount * math.Pow(10, -float64(OTokensDecimals)),
 			})
 	}
 
@@ -360,13 +360,13 @@ func normalize(instruments []getOptionsOtokensOToken, provider string, amount fl
 			}
 
 			o.Bid = append(o.Bid, rainbow.Order{
-				Price:    price,
-				Quantity: amount,
+				Px:   price,
+				Size: amount,
 			})
 		} else {
 			o.Bid = append(o.Bid, rainbow.Order{
-				Price:    0.0,
-				Quantity: 0.0,
+				Px:   0.0,
+				Size: 0.0,
 			})
 		}
 
@@ -383,13 +383,13 @@ func normalize(instruments []getOptionsOtokensOToken, provider string, amount fl
 			}
 
 			o.Ask = append(o.Ask, rainbow.Order{
-				Price:    price,
-				Quantity: amount,
+				Px:   price,
+				Size: amount,
 			})
 		} else {
 			o.Ask = append(o.Ask, rainbow.Order{
-				Price:    0.0,
-				Quantity: 0.0,
+				Px:   0.0,
+				Size: 0.0,
 			})
 		}
 

--- a/pkg/provider/zerox/opyn.go
+++ b/pkg/provider/zerox/opyn.go
@@ -49,8 +49,6 @@ func QueryTheGraph() []getOptionsOtokensOToken {
 }
 
 func filterExpired(instruments []getOptionsOtokensOToken, date time.Time) (filtered []getOptionsOtokensOToken) {
-	// oct29th, _ := time.Parse(time.RFC3339, "2021-10-29T08:00:00Z")
-
 	for _, i := range instruments {
 		seconds, err := strconv.ParseInt(i.ExpiryTimestamp, 10, 0)
 		if err != nil {

--- a/pkg/rainbow/cache.go
+++ b/pkg/rainbow/cache.go
@@ -12,7 +12,7 @@ import (
 
 type Cache struct {
 	options     []Option
-	cpFormat    CPFormat
+	callPut     CallPut
 	initialized bool
 }
 
@@ -20,7 +20,7 @@ func NewCache() Cache {
 	return Cache{
 		initialized: false,
 		options:     []Option{},
-		cpFormat:    CPFormat{Rows: []Row{}},
+		callPut:     CallPut{Rows: []Row{}},
 	}
 }
 
@@ -31,7 +31,7 @@ func (c Cache) Empty() bool {
 func (c *Cache) Refresh(options []Option) {
 	c.initialized = true
 	c.options = options
-	c.cpFormat = buildCPFormat(options)
+	c.callPut = buildCPFormat(options)
 }
 
 func (c *Cache) Options() ([]Option, error) {
@@ -42,10 +42,10 @@ func (c *Cache) Options() ([]Option, error) {
 	return c.options, nil
 }
 
-func (c *Cache) CPFormat() (CPFormat, error) {
+func (c *Cache) CallPut() (CallPut, error) {
 	if c.Empty() {
-		return c.cpFormat, fmt.Errorf("Cache is empty")
+		return c.callPut, fmt.Errorf("Cache is empty")
 	}
 
-	return c.cpFormat, nil
+	return c.callPut, nil
 }

--- a/pkg/rainbow/handler.go
+++ b/pkg/rainbow/handler.go
@@ -49,7 +49,7 @@ func (h handler) getOptions(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h handler) getCPFormat(w http.ResponseWriter, r *http.Request) {
-	cp, err := h.c.CPFormat()
+	cp, err := h.c.CallPut()
 	if err != nil {
 		log.Print("ERROR getCPFormat ", err)
 		http.Error(w, "No Content", http.StatusNoContent)
@@ -67,7 +67,7 @@ func (h handler) getCPFormat(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type CPFormat struct {
+type CallPut struct {
 	Rows []Row `json:"rows"`
 }
 
@@ -88,7 +88,7 @@ type OptionIndicators struct {
 	Ask Order `json:"ask"`
 }
 
-func buildCPFormat(options []Option) CPFormat {
+func buildCPFormat(options []Option) CallPut {
 	rows := make([]Row, 0, len(options)/2)
 
 	for asset, optionsSameAsset := range groupByAsset(options) {
@@ -116,7 +116,7 @@ func buildCPFormat(options []Option) CPFormat {
 		}
 	}
 
-	return CPFormat{Rows: rows}
+	return CallPut{Rows: rows}
 }
 
 func groupByAsset(options []Option) (assetToOptions map[string][]Option) {

--- a/pkg/rainbow/handler.go
+++ b/pkg/rainbow/handler.go
@@ -84,13 +84,8 @@ type Row struct {
 }
 
 type OptionIndicators struct {
-	Bid SimpleOrder `json:"bid"`
-	Ask SimpleOrder `json:"ask"`
-}
-
-type SimpleOrder struct {
-	Price float64 `json:"px"`
-	Size  float64 `json:"size"`
+	Bid Order `json:"bid"`
+	Ask Order `json:"ask"`
 }
 
 func buildCPFormat(options []Option) CPFormat {
@@ -186,18 +181,16 @@ func groupByProvider(options []Option) (providerToOptions map[string][]Option) {
 
 func newOptionIndicators(o Option) OptionIndicators {
 	oi := OptionIndicators{
-		Bid: SimpleOrder{Price: 0, Size: 0},
-		Ask: SimpleOrder{Price: 0, Size: 0},
+		Bid: Order{Px: 0, Size: 0},
+		Ask: Order{Px: 0, Size: 0},
 	}
 
 	if len(o.Bid) > 0 {
-		oi.Bid.Price = o.Bid[0].Price
-		oi.Bid.Size = o.Bid[0].Quantity
+		oi.Bid = o.Bid[0]
 	}
 
 	if len(o.Ask) > 0 {
-		oi.Ask.Price = o.Ask[0].Price
-		oi.Ask.Size = o.Ask[0].Quantity
+		oi.Ask = o.Ask[0]
 	}
 
 	return oi

--- a/pkg/rainbow/option.go
+++ b/pkg/rainbow/option.go
@@ -26,8 +26,15 @@ type Option struct {
 }
 
 type Order struct {
-	Px   float64 `json:"px"`   // Px is an abbreviation for "Price" (e.g. FIX protocol).
-	Size float64 `json:"size"` // Size is often used in lieu of the longer word "Quantity".
+	// Px is a known abbreviation for "Price" used by many Centralized Exchanges
+	// such as in the FIX protocol: https://fiximate.fixtrading.org/legacy/en/FIX.5.0SP2/abbreviations.html
+	// Independently of the FIX protocol, "Px" is intensively used at Euronext.
+	// "Px" is also a French abbreviation for "Prix". :-)
+	// Rainbow uses "px" in the API (JSON)) but uses "price" on the front-end side.
+	Px float64 `json:"px"`
+
+	// Size is often used in lieu of the longer word "Quantity".
+	Size float64 `json:"size"`
 }
 
 func BestLimitStr(option Option) (bestBidPx, bestBidSz, bestAskPx, bestAskSz string) {

--- a/pkg/rainbow/option.go
+++ b/pkg/rainbow/option.go
@@ -26,22 +26,22 @@ type Option struct {
 }
 
 type Order struct {
-	Price    float64
-	Quantity float64
+	Px   float64 `json:"px"`   // Px is an abbreviation for "Price" (e.g. FIX protocol).
+	Size float64 `json:"size"` // Size is often used in lieu of the longer word "Quantity".
 }
 
-func BestLimitStr(option Option) (bestBidPx, bestBidQty, bestAskPx, bestAskQty string) {
-	bestBidPx, bestBidQty = none, none
-	bestAskPx, bestAskQty = none, none
+func BestLimitStr(option Option) (bestBidPx, bestBidSz, bestAskPx, bestAskSz string) {
+	bestBidPx, bestBidSz = none, none
+	bestAskPx, bestAskSz = none, none
 
 	if len(option.Bid) > 0 {
-		bestBidPx = alignFloatOnDecimalPoint(option.Bid[0].Price)
-		bestBidQty = alignFloatOnDecimalPoint(option.Bid[0].Quantity)
+		bestBidPx = alignFloatOnDecimalPoint(option.Bid[0].Px)
+		bestBidSz = alignFloatOnDecimalPoint(option.Bid[0].Size)
 	}
 
 	if len(option.Ask) > 0 {
-		bestAskPx = alignFloatOnDecimalPoint(option.Ask[0].Price)
-		bestAskQty = alignFloatOnDecimalPoint(option.Ask[0].Quantity)
+		bestAskPx = alignFloatOnDecimalPoint(option.Ask[0].Px)
+		bestAskSz = alignFloatOnDecimalPoint(option.Ask[0].Size)
 	}
 
 	return

--- a/pkg/rainbow/option.go
+++ b/pkg/rainbow/option.go
@@ -79,21 +79,3 @@ func alignFloatOnDecimalPoint(f float64) string {
 
 	return string(b)
 }
-
-// WIP new implementation
-//
-// type Order struct{ Px, Qty string }
-// type Limit struct{ Bid, Ask Order }
-//
-// func NewLimit() Limit {
-// 	return Limit{
-// 		Bid: Order{
-// 			Px:  none,
-// 			Qty: none,
-// 		},
-// 		Ask: Order{
-// 			Px:  none,
-// 			Qty: none,
-// 		},
-// 	}
-// }

--- a/pkg/rainbow/option.go
+++ b/pkg/rainbow/option.go
@@ -11,18 +11,18 @@ import (
 )
 
 type Option struct {
-	Name          string // ASSET-DATE-Strike-OptionsType
-	Type          string // CALL / PUT
-	Asset         string // ETH, BTC, SOL
-	Expiry        string // Expiry date in format 2021-12-31
-	Strike        float64
-	ExchangeType  string // CEX / DEX
-	Chain         string // Ethereum, Solana and "–" for CEX (Deribit)
-	Layer         string // L1, L2 and "–" for CEX (Deribit)
-	Provider      string // Opyn, Lyra, Thales, Deribit, Psyoptions
-	QuoteCurrency string // ETH, BTC, USDT...
-	Bid           []Order
-	Ask           []Order
+	Name          string  `json:"name"`     // ASSET-DATE-Strike-OptionsType
+	Type          string  `json:"type"`     // CALL / PUT
+	Asset         string  `json:"asset"`    // ETH, BTC, SOL
+	Expiry        string  `json:"expiry"`   // Expiry date in format 2021-12-31
+	ExchangeType  string  `json:"exchange"` // CEX / DEX
+	Chain         string  `json:"chain"`    // Ethereum, Solana and "–" for CEX (Deribit)
+	Layer         string  `json:"layer"`    // L1, L2 and "–" for CEX (Deribit)
+	Provider      string  `json:"provider"` // Opyn, Lyra, Thales, Deribit, Psyoptions
+	QuoteCurrency string  `json:"currency"` // ETH, BTC, USDT...
+	Bid           []Order `json:"bid"`
+	Ask           []Order `json:"ask"`
+	Strike        float64 `json:"strike"`
 }
 
 type Order struct {

--- a/pkg/rainbow/option.go
+++ b/pkg/rainbow/option.go
@@ -11,23 +11,23 @@ import (
 )
 
 type Option struct {
-	Name         string // ASSET-DATE-Strike-OptionsType
-	Type         string // CALL / PUT
-	Asset        string // ETH, BTC, SOL
-	Expiry       string // Expiry date in format 2021-12-31
-	Strike       float64
-	ExchangeType string // CEX / DEX
-	Chain        string // Ethereum, Solana and "–" for CEX (Deribit)
-	Layer        string // L1, L2 and "–" for CEX (Deribit)
-	Provider     string // Opyn, Lyra, Thales, Deribit, Psyoptions
-	Bid          []Order
-	Ask          []Order
+	Name          string // ASSET-DATE-Strike-OptionsType
+	Type          string // CALL / PUT
+	Asset         string // ETH, BTC, SOL
+	Expiry        string // Expiry date in format 2021-12-31
+	Strike        float64
+	ExchangeType  string // CEX / DEX
+	Chain         string // Ethereum, Solana and "–" for CEX (Deribit)
+	Layer         string // L1, L2 and "–" for CEX (Deribit)
+	Provider      string // Opyn, Lyra, Thales, Deribit, Psyoptions
+	QuoteCurrency string // ETH, BTC, USDT...
+	Bid           []Order
+	Ask           []Order
 }
 
 type Order struct {
-	Price         float64
-	Quantity      float64
-	QuoteCurrency string // ETH, BTC, USDT...
+	Price    float64
+	Quantity float64
 }
 
 func BestLimitStr(option Option) (bestBidPx, bestBidQty, bestAskPx, bestAskQty string) {


### PR DESCRIPTION
- [x] Move the `QuoteCurrency` field from `Order` type to `Option` type
- [x] Shorten `Price` / `Quantity` -> `Px` / `Size`
- [x] Reuse `Order` struct in `CPFormat`
- [x] Rename `CPFormat` to `CallPut`