### PR TITLE
Separate `[]Option` by Provider

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/gookit/color"
@@ -20,13 +19,9 @@ import (
 )
 
 func main() {
-	service := rainbow.NewService(provider.AllProvider{}, &dbram.DB{})
+	service := rainbow.NewService(provider.AllProviders(), &dbram.DB{})
 
-	options, err := service.OptionsFromProviders()
-	if err != nil {
-		log.Print("ERROR: ", err)
-		return
-	}
+	options := service.OptionsFromProviders()
 
 	printTable(options)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	// Start the service in background
 	service := rainbow.NewService(
-		provider.AllProvider{},
+		provider.AllProviders(),
 		&dbram.DB{},
 	)
 	go service.Run()

--- a/pkg/provider/deribit/deribit.go
+++ b/pkg/provider/deribit/deribit.go
@@ -19,7 +19,13 @@ import (
 	"github.com/teal-finance/rainbow/pkg/rainbow"
 )
 
-func Options() ([]rainbow.Option, error) {
+type Provider struct{}
+
+func (Provider) Name() string {
+	return "Deribit"
+}
+
+func (Provider) Options() ([]rainbow.Option, error) {
 	instruments, err := query("BTC")
 	if err != nil {
 		log.Print(err)

--- a/pkg/provider/providers.go
+++ b/pkg/provider/providers.go
@@ -7,42 +7,17 @@
 package provider
 
 import (
-	"fmt"
-
 	"github.com/teal-finance/rainbow/pkg/provider/deribit"
 	"github.com/teal-finance/rainbow/pkg/provider/psyoptions"
 	"github.com/teal-finance/rainbow/pkg/provider/zerox"
 	"github.com/teal-finance/rainbow/pkg/rainbow"
 )
 
-// AllProvider gets data from all providers.
-type AllProvider struct{}
-
-func (p AllProvider) Options() ([]rainbow.Option, error) {
-	options := []rainbow.Option{}
-
-	// psy
-	psy, err := psyoptions.Options()
-	if err != nil {
-		return nil, fmt.Errorf("getting data from psy : %w", err)
+// AllProviders returns all active providers.
+func AllProviders() []rainbow.Provider {
+	return []rainbow.Provider{
+		psyoptions.Provider{},
+		zerox.Provider{},
+		deribit.Provider{},
 	}
-
-	options = append(options, psy...)
-
-	// opyn
-	op, err := zerox.Options()
-	if err != nil {
-		return nil, fmt.Errorf("getting data from opyn : %w", err)
-	}
-
-	options = append(options, op...)
-
-	der, err := deribit.Options()
-	if err != nil {
-		return nil, fmt.Errorf("getting data from deribit : %w", err)
-	}
-
-	options = append(options, der...)
-
-	return options, nil
 }

--- a/pkg/provider/psyoptions/psyoptions.go
+++ b/pkg/provider/psyoptions/psyoptions.go
@@ -25,7 +25,13 @@ const (
 	devnet           = "https://api.devnet.solana.com"
 )
 
-func Options() ([]rainbow.Option, error) {
+type Provider struct{}
+
+func (Provider) Name() string {
+	return "PsyOptions"
+}
+
+func (p Provider) Options() ([]rainbow.Option, error) {
 	// instruments := append(oldInstruments("ETH"), oldInstruments("BTC")...)
 	instruments := query()
 	client := rpc.NewClient(mainnet)

--- a/pkg/provider/zerox/opyn.go
+++ b/pkg/provider/zerox/opyn.go
@@ -17,7 +17,13 @@ import (
 	"github.com/teal-finance/rainbow/pkg/rainbow"
 )
 
-func Options() ([]rainbow.Option, error) {
+type Provider struct{}
+
+func (Provider) Name() string {
+	return "Opyn"
+}
+
+func (Provider) Options() ([]rainbow.Option, error) {
 	instruments := QueryTheGraph()
 
 	options, err := normalize(instruments, "Opyn", 1.0)

--- a/pkg/rainbow/storage/dbram/dbram.go
+++ b/pkg/rainbow/storage/dbram/dbram.go
@@ -7,19 +7,46 @@
 package dbram
 
 import (
+	"fmt"
+
 	"github.com/teal-finance/rainbow/pkg/rainbow"
 )
 
 // DB client.
 type DB struct {
-	options []rainbow.Option
+	// optionsByProvider separates the options by provider
+	optionsByProvider map[string][]rainbow.Option
 }
 
-func (db *DB) InsertOptions(options []rainbow.Option) error {
-	db.options = options
+func (db *DB) InsertOptions(p string, options []rainbow.Option) error {
+	if db.optionsByProvider == nil {
+		db.optionsByProvider = map[string][]rainbow.Option{p: options}
+	} else {
+		db.optionsByProvider[p] = options
+	}
+
 	return nil
 }
 
+func (db *DB) GetOptions(p string) ([]rainbow.Option, error) {
+	options, ok := db.optionsByProvider[p]
+	if !ok {
+		return nil, fmt.Errorf("No data for %q", p)
+	}
+
+	return options, nil
+}
+
 func (db *DB) GetAllOptions() ([]rainbow.Option, error) {
-	return db.options, nil
+	n := 0
+	for _, o := range db.optionsByProvider {
+		n += len(o)
+	}
+
+	options := make([]rainbow.Option, 0, n)
+	for _, o := range db.optionsByProvider {
+		options = append(options, o...)
+	}
+
+	return options, nil
 }


### PR DESCRIPTION
The current main branch fails when one of the providers is experimenting issues (e.g. TCP timeout), even if all other data has been successfully fetched from the other providers.

This PR stores in the DB the `[]Option` of each individual provider. Like that, when a provider fails, we reuse the previously stored data. I dislike mixing data from all providers in DB. I like when the fetched data is separated by provider.