### PR TITLE
Fix sorting in datatable

### DIFF
--- a/frontend/src/packages/datatable/models/datatable.ts
+++ b/frontend/src/packages/datatable/models/datatable.ts
@@ -19,7 +19,7 @@ export default class SwDatatableModel<T = Record<string, any>> {
   constructor({ columns, rows, idCol }: TableParams<T> = {}) {
     this._initialState = reactive<TableInterface<T>>({
       columns: columns ?? {},
-      rows: rows ?? [],
+      rows: [...rows ?? []],
     });
     this.state = reactive<TableInterface<T>>({
       columns: columns ?? {},


### PR DESCRIPTION
This fixes the sorting by reenabling the default order when sorting is disabled on a column with the arrow icon