### PR TITLE
👷 Bump Go from 1.18 to 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ARG uid=5505
 # base = /rainbow/
 
 # --------------------------------------------------------------------
-FROM docker.io/golang:1.18 AS version
+FROM docker.io/golang:1.19 AS version
 
 WORKDIR /code
 
@@ -137,7 +137,7 @@ RUN set -ex                                            ;\
     yarn compress
 
 # --------------------------------------------------------------------
-FROM docker.io/golang:1.18 AS integrator
+FROM docker.io/golang:1.19 AS integrator
 
 WORKDIR /target
 


### PR DESCRIPTION
The Dockerfile using Go-1.19 fails to build the container image.

The command `make container-build` that is similar to `docker build .` successfully builds the Go backend, but the smoke test fails.

The smoke test is the execution of `./server -version`

### smoke test output

```
+ ./server -version
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xc6d606]

goroutine 1 [running]:
debug/elf.(*Section).ReadAt(0xc0004da000?, {0xc0003d6240?, 0x1c8?, 0x17?}, 0x40?)
        <autogenerated>:1 +0x26
archive/zip.readDirectoryEnd({0x1318480, 0xc0001dba00}, 0x210)
        archive/zip/reader.go:526 +0xf5
archive/zip.(*Reader).init(0xc00031a8c0, {0x1318480?, 0xc0001dba00}, 0x210)
        archive/zip/reader.go:97 +0x5c
archive/zip.NewReader({0x1318480, 0xc0001dba00}, 0x210)
        archive/zip/reader.go:90 +0x5e
github.com/daaku/go%2ezipexe.zipExeReaderElf({0x131a520?, 0xc0000123d8}, 0x20281f3)
        github.com/daaku/go.zipexe@v1.0.0/zipexe.go:128 +0x8b
github.com/daaku/go%2ezipexe.NewReader({0x131a520, 0xc0000123d8}, 0x0?)
        github.com/daaku/go.zipexe@v1.0.0/zipexe.go:48 +0x98
github.com/daaku/go%2ezipexe.OpenCloser({0xc0002f9470?, 0xc000481980?})
        github.com/daaku/go.zipexe@v1.0.0/zipexe.go:30 +0x57
github.com/GeertJohan/go%2erice.init.0()
        github.com/GeertJohan/go.rice@v1.0.0/appended.go:41 +0x65
```

I am not able to reproduce this issue on my local machine using Go-1.19. :-/